### PR TITLE
Update README Usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,6 @@ Execution environment: Java SE 6
 ## Usage
 
 ``` bash
-javac BlockBreak.java
+javac -encoding utf-8 BlockBreak.java
 java BlockBreak
 ```


### PR DESCRIPTION
コンパイル時に「エラー: この文字は、エンコーディングMS932にマップできません」が起きるのを解消する